### PR TITLE
Enable automatic testing via github actions (on master branch)

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -1,0 +1,21 @@
+name: .NET Core
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.101
+    - name: Build with dotnet
+      run: dotnet test --configuration Release

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ nuget.exe
 packages/
 *.nupkg
 runGitVersionPropagate.bat
+/_ReSharper.Caches/

--- a/OldSchool.I18n.Lib.Tests/I18nCsCollectorTests.fs
+++ b/OldSchool.I18n.Lib.Tests/I18nCsCollectorTests.fs
@@ -13,8 +13,7 @@ type CsExtractorTests(log:ITestOutputHelper) =
     let fileName = """c:\smthelse"""
 
     let doTest csFileName =
-        let dir = System.Reflection.Assembly.GetExecutingAssembly().Location |> Path.GetDirectoryName
-        let filePath = Path.Combine(dir, "../../../../OldSchool.I18n.Lib.Tests.CsFiles", csFileName)
+        let filePath = Path.Combine("CsFiles", csFileName)
         CsExtractor.ExtractCs i18Class [i18Method] fileName (File.ReadAllText filePath)
 
     [<Fact>]

--- a/OldSchool.I18n.Lib.Tests/OldSchool.I18n.Lib.Tests.fsproj
+++ b/OldSchool.I18n.Lib.Tests/OldSchool.I18n.Lib.Tests.fsproj
@@ -8,9 +8,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Include="..\OldSchool.I18n.Lib.Tests.CsFiles\*.cs" Link="CsFiles\%(Filename)%(Extension)">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <Compile Include="I18nCsCollectorTests.fs" />
     <Compile Include="I18nFsCollectorTests.fs" />
     <Compile Include="ExtractionTests.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="CsFiles\" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Rationale: run tests automatically when code is pushed to master

Uses github Actions to launch `dotnet test` command. 
Special [workflow file](https://github.com/d-p-y/oldschool-i18n/blob/49f912a2dcde541563452c1175c80c2b37138294/.github/workflows/dotnetcore.yml) was added to repo - github recognizes it and registers an action to execute in specified moment (trigger).

It creates windows OS, installs netcore tools and then runs `dotnet tests`

In addition to workflow file, changes were made in test project in order to enable proper `dotnet test` runs. In particular - test C# files are now copied to output dir of test project and tests reference them by relative path - working dir happens to be set output dir when using `dotnet test`.